### PR TITLE
Remove lambdified functions upon pickling, restore when unpickling

### DIFF
--- a/neat/channels/ionchannels.py
+++ b/neat/channels/ionchannels.py
@@ -160,11 +160,27 @@ class IonChannel(object):
         self.setLambdaFuncs()
 
     def __getstate__(self):
-        self.unsetLambdaFuncs()
-        return self.__dict__
+
+        d = dict(self.__dict__)
+
+        # remove lambdified functions from dict as they can not be
+        # pickled
+        del d['f_statevar']
+        del d['f_varinf']
+        del d['f_tauinf']
+        del d['f_p_open']
+        del d['dp_dx'], d['df_dv'], d['df_dx'], d['df_dc']
+        del d['f_s00']
+
+        return d
+
 
     def __setstate__(self, s):
+
         self.__dict__ = s
+
+        # since lambdified functions were not pickled we need to
+        # restore them
         self.setLambdaFuncs()
 
     def setLambdaFuncs(self):
@@ -188,14 +204,6 @@ class IonChannel(object):
         # print self.p_open
         # print sol
         self.f_s00 = sp.lambdify((self.statevars, self.po), sol)
-
-    def unsetLambdaFuncs(self):
-        del self.f_statevar
-        del self.f_varinf
-        del self.f_tauinf
-        del self.f_p_open
-        del self.dp_dx, self.df_dv, self.df_dx, self.df_dc
-        del self.f_s00
 
     def _substituteConc(self, expr):
         for sp_c, ion in zip(self.sp_c, self.concentrations):

--- a/tests/test_ionchannels.py
+++ b/tests/test_ionchannels.py
@@ -54,6 +54,21 @@ class TestChannels():
         # TODO
 
 
+def test_pickling():
+
+    # pickle and restore
+    na_ta_channel = channelcollection.Na_Ta()
+    s = pickle.dumps(na_ta_channel)
+    new_na_ta_channel = pickle.loads(s)
+
+    # multiple pickles
+    s = pickle.dumps(na_ta_channel)
+    s = pickle.dumps(na_ta_channel)
+    new_na_ta_channel = pickle.loads(s)
+
+    assert True  # reaching this means we didn't encounter an error
+
+
 if __name__ == '__main__':
     tcns = TestChannels()
     tcns.testBasic()


### PR DESCRIPTION
Following https://docs.python.org/3/library/pickle.html#pickling-class-instances this PR defines the `__getstate__` and `__setstate__` methods for the `IonChannel` class to support pickling of instances. It removes the lambdified functions before pickling and restores them during unpickling.

This has not been tested, @WillemWybo can you give this a try?

fixes #25 

[edit]
this code works:
```python
na_ta_channel = Na_Ta()
s = pickle.dumps(na_ta_channel)
new_na_ta_channel = pickle.loads(s)
```
[/edit]