### PR TITLE
Fix paths to test morphologies

### DIFF
--- a/tests/test_cnet.py
+++ b/tests/test_cnet.py
@@ -1,4 +1,5 @@
 import numpy as np
+import os
 
 import pytest
 
@@ -9,6 +10,9 @@ from neat import GreensTree, NeuronSimTree, SOVTree
 from neat.channels.channelcollection import channelcollection
 
 
+MORPHOLOGIES_PATH_PREFIX = os.path.abspath(os.path.join(os.path.dirname(__file__), 'test_morphologies'))
+
+
 class TestCNET():
     def createPointNeurons(self, v_eq=-75.):
         self.v_eq = v_eq
@@ -16,7 +20,7 @@ class TestCNET():
         gh, eh = 50., -43.
         h_chan = channelcollection.h()
 
-        self.greens_tree = GreensTree(file_n='test_morphologies/ball.swc')
+        self.greens_tree = GreensTree(file_n=os.path.join(MORPHOLOGIES_PATH_PREFIX, 'ball.swc'))
         self.greens_tree.setPhysiology(1., 100./1e6)
         self.greens_tree.addCurrent(h_chan, gh, eh)
         self.greens_tree.fitLeakCurrent(v_eq, 10.)

--- a/tests/test_compartmentfitter.py
+++ b/tests/test_compartmentfitter.py
@@ -1,5 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as pl
+import os
 
 import pytest
 import random
@@ -15,6 +16,9 @@ from neat.channels.channelcollection import channelcollection
 import neat.tools.fittools.compartmentfitter as compartmentfitter
 
 
+MORPHOLOGIES_PATH_PREFIX = os.path.join(os.path.abspath(os.path.join(os.path.dirname(__file__))), 'test_morphologies')
+
+
 class TestCompartmentFitter():
     def loadTTree(self):
         '''
@@ -26,7 +30,7 @@ class TestCompartmentFitter():
                 1
         '''
         print('>>> loading T-tree <<<')
-        fname = 'test_morphologies/Tsovtree.swc'
+        fname = os.path.join(MORPHOLOGIES_PATH_PREFIX, 'Tsovtree.swc')
         self.tree = PhysTree(fname, types=[1,3,4])
         self.tree.setPhysiology(0.8, 100./1e6)
         self.tree.fitLeakCurrent(-75., 10.)
@@ -38,7 +42,7 @@ class TestCompartmentFitter():
 
         1--4
         '''
-        self.tree = PhysTree(file_n='test_morphologies/ball_and_stick.swc')
+        self.tree = PhysTree(file_n=os.path.join(MORPHOLOGIES_PATH_PREFIX, 'ball_and_stick.swc'))
         self.tree.setPhysiology(0.8, 100./1e6)
         self.tree.setLeakCurrent(100., -75.)
         self.tree.setCompTree()
@@ -47,7 +51,7 @@ class TestCompartmentFitter():
         '''
         Load point neuron model
         '''
-        self.tree = PhysTree(file_n='test_morphologies/ball.swc')
+        self.tree = PhysTree(file_n=os.path.join(MORPHOLOGIES_PATH_PREFIX, 'ball.swc'))
         # capacitance and axial resistance
         self.tree.setPhysiology(0.8, 100./1e6)
         # ion channels
@@ -66,8 +70,8 @@ class TestCompartmentFitter():
         '''
         Load point neuron model
         '''
-        self.tree = PhysTree(file_n='test_morphologies/Ttree_segments.swc')
-        # self.tree = PhysTree(file_n='test_morphologies/L23PyrBranco.swc')
+        self.tree = PhysTree(file_n=os.path.join(MORPHOLOGIES_PATH_PREFIX, 'Ttree_segments.swc'))
+        # self.tree = PhysTree(file_n=os.path.join(MORPHOLOGIES_PATH_PREFIX, 'L23PyrBranco.swc'))
         # capacitance and axial resistance
         self.tree.setPhysiology(0.8, 100./1e6)
         # ion channels

--- a/tests/test_compartmenttree.py
+++ b/tests/test_compartmenttree.py
@@ -1,5 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as pl
+import os
 
 import pytest
 import random
@@ -8,6 +9,9 @@ import copy
 from neat import SOVTree, SOVNode, Kernel, GreensTree, CompartmentTree, CompartmentNode
 import neat.tools.kernelextraction as ke
 from neat.channels.channelcollection import channelcollection
+
+
+MORPHOLOGIES_PATH_PREFIX = os.path.abspath(os.path.join(os.path.dirname(__file__), 'test_morphologies'))
 
 
 class TestCompartmentTree():
@@ -21,7 +25,7 @@ class TestCompartmentTree():
                 1
         """
         print('>>> loading T-tree <<<')
-        fname = 'test_morphologies/Tsovtree.swc'
+        fname = os.path.join(MORPHOLOGIES_PATH_PREFIX, 'Tsovtree.swc')
         self.tree = SOVTree(fname, types=[1,3,4])
         self.tree.fitLeakCurrent(-75., 10.)
         self.tree.setCompTree()
@@ -132,7 +136,7 @@ class TestCompartmentTree():
         assert all([loc == loc_ for loc, loc_ in zip(locs_equiv, [(0, .5), (2, .5), (1, .5)])])
 
     def loadBallAndStick(self):
-        self.greens_tree = GreensTree(file_n='test_morphologies/ball_and_stick.swc')
+        self.greens_tree = GreensTree(file_n=os.path.join(MORPHOLOGIES_PATH_PREFIX, 'ball_and_stick.swc'))
         self.greens_tree.setPhysiology(0.8, 100./1e6)
         self.greens_tree.setLeakCurrent(100., -75.)
         self.greens_tree.setCompTree()
@@ -291,7 +295,7 @@ class TestCompartmentTree():
                            np.ones(len(self.ctree)) * np.max(1e-3/np.abs(alphas)))
 
     def loadBall(self):
-        self.greens_tree = GreensTree(file_n='test_morphologies/ball.swc')
+        self.greens_tree = GreensTree(file_n=os.path.join(MORPHOLOGIES_PATH_PREFIX, 'ball.swc'))
         # capacitance and axial resistance
         self.greens_tree.setPhysiology(0.8, 100./1e6)
         # ion channels

--- a/tests/test_greenstree.py
+++ b/tests/test_greenstree.py
@@ -1,10 +1,14 @@
 import numpy as np
 import matplotlib.pyplot as pl
+import os
 
 import pytest
 
 from neat import SOVTree, GreensTree, GreensNode
 import neat.tools.kernelextraction as ke
+
+
+MORPHOLOGIES_PATH_PREFIX = os.path.abspath(os.path.join(os.path.dirname(__file__), 'test_morphologies'))
 
 
 class TestGreensTree():
@@ -18,7 +22,7 @@ class TestGreensTree():
                 1
         """
         print('>>> loading T-tree <<<')
-        fname = 'test_morphologies/Tsovtree.swc'
+        fname = os.path.join(MORPHOLOGIES_PATH_PREFIX, 'Tsovtree.swc')
         self.tree = GreensTree(fname, types=[1,3,4])
         self.tree.fitLeakCurrent(-75., 10.)
         self.tree.setCompTree()
@@ -30,7 +34,7 @@ class TestGreensTree():
         5---1---4
         """
         print('>>> loading validation tree <<<')
-        fname = 'test_morphologies/sovvalidationtree.swc'
+        fname = os.path.join(MORPHOLOGIES_PATH_PREFIX, 'sovvalidationtree.swc')
         self.tree = GreensTree(fname, types=[1,3,4])
         self.tree.fitLeakCurrent(-75., 10.)
         self.tree.setCompTree()
@@ -45,7 +49,7 @@ class TestGreensTree():
                 1
         """
         print('>>> loading T-tree <<<')
-        fname = 'test_morphologies/Tsovtree.swc'
+        fname = os.path.join(MORPHOLOGIES_PATH_PREFIX, 'Tsovtree.swc')
         self.sovtree = SOVTree(fname, types=[1,3,4])
         self.sovtree.fitLeakCurrent(-75., 10.)
         self.sovtree.setCompTree()
@@ -58,7 +62,7 @@ class TestGreensTree():
         5---1---4
         """
         print('>>> loading validation tree <<<')
-        fname = 'test_morphologies/sovvalidationtree.swc'
+        fname = os.path.join(MORPHOLOGIES_PATH_PREFIX, 'sovvalidationtree.swc')
         self.sovtree = SOVTree(fname, types=[1,3,4])
         self.sovtree.fitLeakCurrent(-75., 10.)
         self.sovtree.setCompTree()
@@ -191,7 +195,7 @@ class TestGreensTree():
 
         # import morphologyReader as morphR
         # distr = {'L': {'type': 'fit', 'param': [-65., 10.], 'E': -65.}}
-        # fname = 'test_morphologies/Tsovtree.swc'
+        # fname = os.path.join(MORPHOLOGIES_PATH_PREFIX, 'Tsovtree.swc')
         # gt = morphR.greensTree(fname, ionc_distr=distr, soma_distr=distr, cnodesdistr='all')
         # # gt.set_changenodes()
         # gt.set_impedance(ft.s)

--- a/tests/test_morphtree.py
+++ b/tests/test_morphtree.py
@@ -1,9 +1,13 @@
 import numpy as np
 import matplotlib.pyplot as pl
+import os
 
 import pytest
 
 from neat import MorphTree, MorphNode, MorphLoc
+
+
+MORPHOLOGIES_PATH_PREFIX = os.path.abspath(os.path.join(os.path.dirname(__file__), 'test_morphologies'))
 
 
 class TestMorphTree():
@@ -39,7 +43,7 @@ class TestMorphTree():
         if not hasattr(self, 'tree') or reinitialize:
             print('>>> loading T-tree <<<')
             fname = 'Ttree_segments.swc' if segments else 'Ttree.swc'
-            self.tree = MorphTree('test_morphologies/'+fname, types=[1,3,4])
+            self.tree = MorphTree(os.path.join(MORPHOLOGIES_PATH_PREFIX, fname), types=[1,3,4])
 
     def testLocEquality(self):
         self.loadTree()

--- a/tests/test_neurontree.py
+++ b/tests/test_neurontree.py
@@ -1,5 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as pl
+import os
 
 import neuron
 from neuron import h
@@ -12,6 +13,9 @@ from neat import CompartmentNode, CompartmentTree
 from neat import NeuronSimTree, createReducedNeuronModel
 import neat.tools.kernelextraction as ke
 from neat.channels.channelcollection import channelcollection
+
+
+MORPHOLOGIES_PATH_PREFIX = os.path.abspath(os.path.join(os.path.dirname(__file__), 'test_morphologies'))
 
 
 colours = ['DeepPink', 'Purple', 'MediumSlateBlue', 'Blue', 'Teal',
@@ -36,7 +40,7 @@ class TestNeuron():
         self.ft = ke.FourrierTools(np.arange(0., self.tmax, self.dt))
         # load the morphology
         print('>>> loading T-tree <<<')
-        fname = 'test_morphologies/Tsovtree.swc'
+        fname = os.path.join(MORPHOLOGIES_PATH_PREFIX, 'Tsovtree.swc')
         self.greenstree = GreensTree(fname, types=[1,3,4])
         self.greenstree.fitLeakCurrent(v_eq, 10.)
         self.greenstree.setCompTree()
@@ -64,7 +68,7 @@ class TestNeuron():
         # load the morphology
         print('>>> loading T-tree <<<')
         h_chan = channelcollection.h()
-        fname = 'test_morphologies/Tsovtree.swc'
+        fname = os.path.join(MORPHOLOGIES_PATH_PREFIX, 'Tsovtree.swc')
         self.greenstree = GreensTree(fname, types=[1,3,4])
         self.greenstree.addCurrent(h_chan, 50., -43.)
         self.greenstree.fitLeakCurrent(v_eq, 10.)
@@ -93,7 +97,7 @@ class TestNeuron():
         # load the morphology
         print('>>> loading T-tree <<<')
         test_chan = channelcollection.TestChannel2()
-        fname = 'test_morphologies/Tsovtree.swc'
+        fname = os.path.join(MORPHOLOGIES_PATH_PREFIX, 'Tsovtree.swc')
         self.greenstree = GreensTree(fname, types=[1,3,4])
         self.greenstree.addCurrent(test_chan, 50., -23.)
         self.greenstree.fitLeakCurrent(v_eq, 10.)
@@ -124,7 +128,7 @@ class TestNeuron():
         # load the morphology
         print('>>> loading T-tree <<<')
         test_chan = channelcollection.TestChannel2()
-        fname = 'test_morphologies/Tsovtree.swc'
+        fname = os.path.join(MORPHOLOGIES_PATH_PREFIX, 'Tsovtree.swc')
         self.greenstree = GreensTree(fname, types=[1,3,4])
         self.greenstree.addCurrent(test_chan, 50., 23., node_arg=[self.greenstree[1]])
         self.greenstree.fitLeakCurrent(v_eq, 10.)

--- a/tests/test_phystree.py
+++ b/tests/test_phystree.py
@@ -1,11 +1,15 @@
 import numpy as np
 import matplotlib.pyplot as pl
+import os
 
 import pytest
 import copy
 
 from neat import PhysTree, PhysNode
 from neat.channels.channelcollection import channelcollection
+
+
+MORPHOLOGIES_PATH_PREFIX = os.path.abspath(os.path.join(os.path.dirname(__file__), 'test_morphologies'))
 
 
 class TestPhysTree():
@@ -21,7 +25,7 @@ class TestPhysTree():
         if not hasattr(self, 'tree') or reinitialize:
             print('>>> loading T-tree <<<')
             fname = 'Ttree_segments.swc' if segments else 'Ttree.swc'
-            self.tree = PhysTree('test_morphologies/'+fname, types=[1,3,4])
+            self.tree = PhysTree(os.path.join(MORPHOLOGIES_PATH_PREFIX, fname), types=[1,3,4])
 
 
     def testLeakDistr(self):

--- a/tests/test_sovtree.py
+++ b/tests/test_sovtree.py
@@ -1,9 +1,13 @@
 import numpy as np
 import matplotlib.pyplot as pl
+import os
 
 import pytest
 from neat import SOVTree, SOVNode, Kernel, GreensTree
 import neat.tools.kernelextraction as ke
+
+
+MORPHOLOGIES_PATH_PREFIX = os.path.abspath(os.path.join(os.path.dirname(__file__), 'test_morphologies'))
 
 
 class TestSOVTree():
@@ -17,7 +21,7 @@ class TestSOVTree():
                 1
         """
         print('>>> loading T-tree <<<')
-        fname = 'test_morphologies/Tsovtree.swc'
+        fname = os.path.join(MORPHOLOGIES_PATH_PREFIX, 'Tsovtree.swc')
         self.tree = SOVTree(fname, types=[1,3,4])
         self.tree.fitLeakCurrent(-75., 10.)
         self.tree.setCompTree()
@@ -29,7 +33,7 @@ class TestSOVTree():
         5---1---4
         """
         print('>>> loading validation tree <<<')
-        fname = 'test_morphologies/sovvalidationtree.swc'
+        fname = os.path.join(MORPHOLOGIES_PATH_PREFIX, 'sovvalidationtree.swc')
         self.tree = SOVTree(fname, types=[1,3,4])
         self.tree.fitLeakCurrent(-75., 10.)
         self.tree.setCompTree()
@@ -116,7 +120,7 @@ class TestSOVTree():
         Load point neuron model
         """
         print('>>> loading validation tree <<<')
-        fname = 'test_morphologies/ball.swc'
+        fname = os.path.join(MORPHOLOGIES_PATH_PREFIX, 'ball.swc')
         self.btree = SOVTree(fname, types=[1,3,4])
         self.btree.fitLeakCurrent(-75., 10.)
         self.btree.setCompTree()


### PR DESCRIPTION
This PR makes the path to test morphologies absolute to avoid dependence on where pytest is executed from