### PR TITLE
Add non-functional h module for attempt at doc compilation

### DIFF
--- a/neat/tools/simtools/neuron/fakeh.py
+++ b/neat/tools/simtools/neuron/fakeh.py
@@ -1,0 +1,29 @@
+
+
+def load_file(ss): pass
+def nrn_load_dll(ss): pass
+def Section(name=ss): return None
+def lambda_f(ff): return None
+def pop_section(): return None
+def Shunt(cc): return None
+def epsc_double_exp(cc): return None
+def exp_AMPA_NMDA(cc): return None
+def exp2Syn(cc): return None
+def exp2Syn(cc): return None
+def double_exp_AMPA_NMDA(cc): return None
+def IClamp(cc): return None
+def SinClamp(cc): return None
+def OUClamp(cc): return None
+def WNClamp(cc): return None
+def OUConductance(cc): return None
+def OUReversal(cc): return None
+def SEClamp(cc): return None
+def Vector(): return None
+def VecStim(cc): return None
+def NetCon(cc): return None
+def finitialize(ff): pass
+def pt3dadd(*args, **kwargs): return None
+
+_ref_t = 0.
+dt = 0.
+

--- a/neat/tools/simtools/neuron/neuronmodel.py
+++ b/neat/tools/simtools/neuron/neuronmodel.py
@@ -13,6 +13,7 @@ try:
     from neuron import h
 except ModuleNotFoundError:
     warnings.warn('NEURON not available', UserWarning)
+    import fakeh as h
 
 
 h.load_file("stdlib.hoc") # contains the lambda rule
@@ -48,7 +49,7 @@ class NeuronSimNode(PhysNode):
         super().__init__(index, p3d)
 
     def _makeSection(self, factorlambda=1., pprint=False):
-        compartment = neuron.h.Section(name=str(self.index))
+        compartment = h.Section(name=str(self.index))
         compartment.push()
         # create the compartment
         if self.index == 1:


### PR DESCRIPTION
Fake h module is loaded in `neat/tools/simtools/neuron/neuronmodel.py` if `ModuleNotFoundError` for `import neuron`, to allow documentation generation