### PR TITLE
Add github actions workflow for tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,33 @@
+name: Tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  neat-testsuite:
+    name: NEAT testsuite
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . ${{ matrix.dep }}
+          pip install neuron
+      - name: Compile channels
+        run: |
+          compilechannels default
+      - name: Run tests
+        run: |
+          pytest

--- a/tests/test_morphtree.py
+++ b/tests/test_morphtree.py
@@ -650,7 +650,7 @@ class TestMorphTree():
         for node in self.tree: assert node.index in [1,5,8,10,12]
 
     def testThreePointSoma(self):
-        mtree = MorphTree('test_morphologies/threepoint_soma.swc')
+        mtree = MorphTree(os.path.join(MORPHOLOGIES_PATH_PREFIX, 'threepoint_soma.swc'))
 
         for n, idx in zip(mtree, [1,4,5]):
             assert n.index == idx
@@ -666,7 +666,7 @@ class TestMorphTree():
         assert mtree[1].R == s_radius
 
     def testMultiCylinderSoma(self):
-        mtree = MorphTree('test_morphologies/multicylinder_soma.swc')
+        mtree = MorphTree(os.path.join(MORPHOLOGIES_PATH_PREFIX, 'multicylinder_soma.swc'))
 
         for n, idx in zip(mtree, [1,7,8,9,10]):
             assert n.index == idx
@@ -683,7 +683,7 @@ class TestMorphTree():
 
     def testWrongSoma(self):
         with pytest.raises(ValueError):
-            mtree = MorphTree('test_morphologies/wrong_soma.swc')
+            MorphTree(os.path.join(MORPHOLOGIES_PATH_PREFIX, 'wrong_soma.swc'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds continuous integration to NEAT via github workflows. For every pull request, all tests will be run on three different python version (3.6, 3.7, 3.8) to make sure that the proposed changes to not break anything. Additionally, every merge to master will trigger these tests to make sure master is always working.

Before this PR is merged, the workflow will not show up in this repo, but you can see the output in [my branch](https://github.com/jakobj/NEAT/actions).

fixes #58 