### PR TITLE
More general display availability test

### DIFF
--- a/neat/__init__.py
+++ b/neat/__init__.py
@@ -2,9 +2,13 @@
 import os
 import warnings
 
-if not os.environ.get('DISPLAY'):
-    import matplotlib
+havedisplay = "DISPLAY" in os.environ
+if not havedisplay:
+    exitval = os.system('python -c "import matplotlib.pyplot as plt; plt.figure()"')
+    havedisplay = (exitval == 0)
 
+if not havedisplay:
+    import matplotlib
     matplotlib.use('Agg')
 
 from .trees.stree import STree


### PR DESCRIPTION
Display availability test didn't work on MacOS Monterrey, since no `"DISPLAY"` environment variable was present.

Use a more general test as per [https://stackoverflow.com/questions/8257385/automatic-detection-of-display-availability-with-matplotlib](https://stackoverflow.com/questions/8257385/automatic-detection-of-display-availability-with-matplotlib)