### PR TITLE
Set examples to not plot and fix image paths

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,9 +130,11 @@ add_module_names = False
 sphinx_gallery_conf = {
     'examples_dirs': '../examples',   # path to your example scripts
     'gallery_dirs': 'auto_examples',  # path to where to save gallery generated output
-    'filename_pattern': '/',
+    'plot_gallery': False,
+    'filename_pattern': '/plot',
     'ignore_pattern': r'.*util\.py'
 }
+nbsphinx_execute = 'never'
 
 # The name of the Pygments (syntax highlighting) style to use.
 # pygments_style = 'friendly'

--- a/examples/bac_firing.py
+++ b/examples/bac_firing.py
@@ -2,7 +2,7 @@
 Bac firing
 =================
 
-.. image:: ../../../../figures/bac_firing.png
+.. image:: /figures/bac_firing.png
 """
 
 import numpy as np

--- a/examples/bac_firing_nest.py
+++ b/examples/bac_firing_nest.py
@@ -1,3 +1,10 @@
+"""
+Bac firing NEST
+===============
+
+``compilechannels nest models/channels/channels_hay.py --name bac_firing --nestmlresource bac_firing_syns.nestml``
+"""
+
 import numpy as np
 import nest
 
@@ -8,9 +15,6 @@ import pickle
 from models.L5_pyramid import getL5Pyramid
 from plotutil import *
 
-"""
-compilechannels nest models/channels/channels_hay.py --name bac_firing --nestmlresource bac_firing_syns.nestml
-"""
 nest.Install("bac_firing_neatmodule")
 
 

--- a/examples/basal_ap_backprop.py
+++ b/examples/basal_ap_backprop.py
@@ -2,7 +2,7 @@
 Basal AP Backprop
 =================
 
-.. image:: ../../../../figures/ap_backpropagation.png
+.. image:: /figures/ap_backpropagation.png
 """
 
 import numpy as np

--- a/examples/sequence_discrimination.py
+++ b/examples/sequence_discrimination.py
@@ -2,7 +2,7 @@
 Sequence discrimination
 =================
 
-.. image:: ../../../../figures/sequence_discrimination.png
+.. image:: /figures/sequence_discrimination.png
 """
 
 import sys


### PR DESCRIPTION
This PR fixes how the Python examples are run with Sphinx gallery/ nbsphinx
Executing the examples and notebooks is disabled to allow the docs to be built on Read the Docs eventually  (if it is enabled  nest, neat, and neuron need to be installed, which is not possible on Read the Docs due to timeouts).
This also means the local environment does not need all of these tools to build the docs.

The path to the images is also corrected.

